### PR TITLE
add custom url input to pass to docker

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,11 @@ inputs:
     description: Do not wait for a run to complete before exiting
     required: false
     default: ''
+
+  custom_url:
+    description: Test against an ephemeral (preview) url
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -133,6 +138,11 @@ runs:
         # Set background
         if [ -n "${{ inputs.background }}" ] ; then
           RUN_COMMAND="${RUN_COMMAND} --background"
+        fi
+
+        # Set custom_url
+        if [ -n "${{ inputs.custom_url }}" ] ; then
+          RUN_COMMAND="${RUN_COMMAND} --custom-url '${{ inputs.custom_url }}'"
         fi
 
         echo "::set-output name=command::${RUN_COMMAND}"

--- a/action.yml
+++ b/action.yml
@@ -142,7 +142,7 @@ runs:
 
         # Set custom_url
         if [ -n "${{ inputs.custom_url }}" ] ; then
-          RUN_COMMAND="${RUN_COMMAND} --custom-url '${{ inputs.custom_url }}'"
+          RUN_COMMAND="${RUN_COMMAND} --custom-url ${{ inputs.custom_url }}"
         fi
 
         echo "::set-output name=command::${RUN_COMMAND}"


### PR DESCRIPTION
This lets us pass a preview URL to the cli

```
  ...
  rainforest:
    name: Rainforest QA GitHub Action
    needs: wait_for_preview_deployment
    runs-on: ubuntu-latest
    steps:
      - name: Display the preview url
        run: "echo ${{ needs.wait_for_preview_deployment.outputs.preview_url }}"
      - name: Running the Rainforest Test
        uses: taplytics/github-action@master
        with:
          environment_id: 27323 # Note: This is our test environment ID
          run_group_id: 9915
          crowd: automation
          token: ${{ secrets.RAINFOREST_API_TOKEN }}
          custom_url: ${{ needs.wait_for_preview_deployment.outputs.preview_url }}
```