### PR TITLE
Hotfix for --description flag

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,0 +1,25 @@
+name: Test helper
+description: Wrapper around pr-mpt/actions-assert - https://github.com/marketplace/actions/assert-actual-is-expected
+inputs:
+  each:
+    description: split actual by line and compare each to expected?
+    required: false
+    default: 'false'
+
+  expected:
+    description: what was expected
+    required: true
+
+  actual:
+    description: what was actual
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: pr-mpt/actions-assert@v3
+      with:
+        assertion: npm://@assertions/is-equal
+        each: ${{ inputs.each }}
+        expected: ${{ inputs.expected }}
+        actual: ${{ inputs.actual }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,10 @@ jobs:
           run_group_id: 42
           dry_run: true
       - name: Base case test
-        env:
-          EXPECTED_COMMAND: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --description "rainforestapp/github-action - ${{ github.ref_name }} test 2021-12-31T23:59:59Z" --release "${{ github.sha }}"
-        run: |
-          if [ "${{ steps.test_base.outputs.command }}" != "${EXPECTED_COMMAND}" ] ; then
-            echo "::error ::expected ${{ steps.test_base.outputs.command }} to equal ${EXPECTED_COMMAND}"
-            exit 1
-          fi
+        uses: ./.github/actions/test
+        with:
+          actual: ${{ steps.test_base.outputs.command }}
+          expected: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --description "rainforestapp/github-action - ${{ github.ref_name }} test 2021-12-31T23:59:59Z" --release "${{ github.sha }}"
       - name: All parameters command
         id: test_all_parameters
         uses: ./
@@ -44,13 +41,10 @@ jobs:
           background: true
           dry_run: true
       - name: All parameters test
-        env:
-          EXPECTED_COMMAND: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --conflict abort-all --environment-id 117 --crowd automation --description "foo bar" --release "1.0" --background
-        run: |
-          if [ "${{ steps.test_all_parameters.outputs.command }}" != "${EXPECTED_COMMAND}" ] ; then
-            echo "::error ::expected ${{ steps.test_all_parameters.outputs.command }} to equal ${EXPECTED_COMMAND}"
-            exit 1
-          fi
+        uses: ./.github/actions/test
+        with:
+          actual: ${{ steps.test_all_parameters.outputs.command }}
+          expected: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --conflict abort-all --environment-id 117 --crowd automation --description "foo bar" --release "1.0" --background
       - name: Custom URL command
         id: test_custom_url
         uses: ./
@@ -62,13 +56,10 @@ jobs:
           release: '1.0'
           dry_run: true
       - name: Custom URL test
-        env:
-          EXPECTED_COMMAND: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --custom-url https://something.com --description "foo bar" --release "1.0"
-        run: |
-          if [ "${{ steps.test_custom_url.outputs.command }}" != "${EXPECTED_COMMAND}" ] ; then
-            echo "::error ::expected ${{ steps.test_custom_url.outputs.command }} to equal ${EXPECTED_COMMAND}"
-            exit 1
-          fi
+        uses: ./.github/actions/test
+        with:
+          actual: ${{ steps.test_custom_url.outputs.command }}
+          expected: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --custom-url "https://something.com" --description "foo bar" --release "1.0"
       - name: Environment ID and Custom URL command
         id: test_environment_id_custom_url
         uses: ./
@@ -81,13 +72,10 @@ jobs:
           release: '1.0'
           dry_run: true
       - name: Environment ID and Custom URL test
-        env:
-          EXPECTED_COMMAND: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --custom-url https://something.com --description "foo bar" --release "1.0"
-        run: |
-          if [ "${{ steps.test_environment_id_custom_url.outputs.command }}" != "${EXPECTED_COMMAND}" ] ; then
-            echo "::error ::expected ${{ steps.test_environment_id_custom_url.outputs.command }} to equal ${EXPECTED_COMMAND}"
-            exit 1
-          fi
+        uses: ./.github/actions/test
+        with:
+          actual: ${{ steps.test_environment_id_custom_url.outputs.command }}
+          expected: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --custom-url "https://something.com" --description "foo bar" --release "1.0"
       - name: Missing token command
         id: test_missing_token
         uses: ./
@@ -95,15 +83,10 @@ jobs:
           dry_run: true
         continue-on-error: true
       - name: Missing token test
-        run: |
-          if [ "${{ steps.test_missing_token.outcome }}" != 'failure' ] ; then
-            echo "::error ::expected ${{ steps.test_missing_token.outcome }} to equal failure"
-            exit 1
-          fi
-          if [ "${{ steps.test_missing_token.outputs.error }}" != 'Token not set' ] ; then
-            echo "::error ::expected ${{ steps.test_missing_token.outputs.error }} to equal Token not set"
-            exit 1
-          fi
+        uses: ./.github/actions/test
+        with:
+          actual: ${{ steps.test_missing_token.outputs.error }}
+          expected: Token not set
       - name: Invalid run group command
         id: test_invalid_run_group
         uses: ./
@@ -113,15 +96,10 @@ jobs:
           dry_run: true
         continue-on-error: true
       - name: Invalid run group test
-        run: |
-          if [ "${{ steps.test_invalid_run_group.outcome }}" != 'failure' ] ; then
-            echo "::error ::expected ${{ steps.test_invalid_run_group.outcome }} to equal failure"
-            exit 1
-          fi
-          if [ "${{ steps.test_invalid_run_group.outputs.error }}" != 'run_group_id not a positive integer (nike)' ] ; then
-            echo "::error ::expected ${{ steps.test_invalid_run_group.outputs.error }} to equal run_group_id not a positive integer (nike)"
-            exit 1
-          fi
+        uses: ./.github/actions/test
+        with:
+          actual: ${{ steps.test_invalid_run_group.outputs.error }}
+          expected: run_group_id not a positive integer (nike)
       - name: Invalid environment ID command
         id: test_invalid_environment_id
         uses: ./
@@ -132,15 +110,10 @@ jobs:
           dry_run: true
         continue-on-error: true
       - name: Invalid environment ID test
-        run: |
-          if [ "${{ steps.test_invalid_environment_id.outcome }}" != 'failure' ] ; then
-            echo "::error ::expected ${{ steps.test_invalid_environment_id.outcome }} to equal failure"
-            exit 1
-          fi
-          if [ "${{ steps.test_invalid_environment_id.outputs.error }}" != 'environment_id not a positive integer (hostile)' ] ; then
-            echo "::error ::expected ${{ steps.test_invalid_environment_id.outputs.error }} to equal environment_id not a positive integer (hostile)"
-            exit 1
-          fi
+        uses: ./.github/actions/test
+        with:
+          actual: ${{ steps.test_invalid_environment_id.outputs.error }}
+          expected: environment_id not a positive integer (hostile)
       - name: Invalid conflict command
         id: test_invalid_conflict
         uses: ./
@@ -151,15 +124,10 @@ jobs:
           dry_run: true
         continue-on-error: true
       - name: Invalid conflict test
-        run: |
-          if [ "${{ steps.test_invalid_conflict.outcome }}" != 'failure' ] ; then
-            echo "::error ::expected ${{ steps.test_invalid_conflict.outcome }} to equal failure"
-            exit 1
-          fi
-          if [ "${{ steps.test_invalid_conflict.outputs.error }}" != 'WWIII not in (abort abort-all)' ] ; then
-            echo "::error ::expected ${{ steps.test_invalid_conflict.outputs.error }} to equal WWIII not in (abort abort-all)"
-            exit 1
-          fi
+        uses: ./.github/actions/test
+        with:
+          actual: ${{ steps.test_invalid_conflict.outputs.error }}
+          expected: WWIII not in (abort abort-all)
       - name: Invalid crowd command
         id: test_invalid_crowd
         uses: ./
@@ -170,15 +138,21 @@ jobs:
           dry_run: true
         continue-on-error: true
       - name: Invalid crowd test
-        run: |
-          if [ "${{ steps.test_invalid_crowd.outcome }}" != 'failure' ] ; then
-            echo "::error ::expected ${{ steps.test_invalid_crowd.outcome }} to equal failure"
-            exit 1
-          fi
-          if [ "${{ steps.test_invalid_crowd.outputs.error }}" != 'hipsters not in (default automation automation_and_crowd on_premise_crowd)' ] ; then
-            echo "::error ::expected ${{ steps.test_invalid_crowd.outputs.error }} to equal hipsters not in (default automation automation_and_crowd on_premise_crowd)"
-            exit 1
-          fi
+        uses: ./.github/actions/test
+        with:
+          actual: ${{ steps.test_invalid_crowd.outputs.error }}
+          expected: hipsters not in (default automation automation_and_crowd on_premise_crowd)
+      - name: Invalid parameter generic test
+        uses: ./.github/actions/test
+        with:
+          each: true
+          actual: |-
+            ${{ steps.test_missing_token.outcome }}
+            ${{ steps.test_invalid_run_group.outcome }}
+            ${{ steps.test_invalid_environment_id.outcome }}
+            ${{ steps.test_invalid_conflict.outcome }}
+            ${{ steps.test_invalid_crowd.outcome }}
+          expected: failure
       - name: Rerun test setup
         run: |
           echo "343" > .rainforest_run_id
@@ -196,10 +170,7 @@ jobs:
           background: true
           dry_run: true
       - name: Rerun test
-        env:
-          EXPECTED_COMMAND: rerun 343 --skip-update --token "test_token" --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --conflict abort --release "1.0" --background
-        run: |
-          if [ "${{ steps.test_rerun.outputs.command }}" != "${EXPECTED_COMMAND}" ] ; then
-            echo "::error ::expected ${{ steps.test_rerun.outputs.command }} to equal ${EXPECTED_COMMAND}"
-            exit 1
-          fi
+        uses: ./.github/actions/test
+        with:
+          actual: ${{ steps.test_rerun.outputs.command }}
+          expected: rerun "343" --skip-update --token "test_token" --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --conflict abort --release "1.0" --background

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           dry_run: true
       - name: Base case test
         env:
-          EXPECTED_COMMAND: run --skip-update --token test_token --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --description 'rainforestapp/github-action - ${{ github.ref_name }} test 2021-12-31T23:59:59Z' --release '${{ github.sha }}'
+          EXPECTED_COMMAND: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --description "rainforestapp/github-action - ${{ github.ref_name }} test 2021-12-31T23:59:59Z" --release "${{ github.sha }}"
         run: |
           if [ "${{ steps.test_base.outputs.command }}" != "${EXPECTED_COMMAND}" ] ; then
             echo "::error ::expected ${{ steps.test_base.outputs.command }} to equal ${EXPECTED_COMMAND}"
@@ -36,7 +36,7 @@ jobs:
         with:
           token: test_token
           run_group_id: 42
-          description: foo
+          description: foo bar
           environment_id: 117
           conflict: abort-all
           crowd: automation
@@ -45,7 +45,7 @@ jobs:
           dry_run: true
       - name: All parameters test
         env:
-          EXPECTED_COMMAND: run --skip-update --token test_token --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --conflict abort-all --environment-id 117 --crowd automation --description 'foo' --release '1.0' --background
+          EXPECTED_COMMAND: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --conflict abort-all --environment-id 117 --crowd automation --description "foo bar" --release "1.0" --background
         run: |
           if [ "${{ steps.test_all_parameters.outputs.command }}" != "${EXPECTED_COMMAND}" ] ; then
             echo "::error ::expected ${{ steps.test_all_parameters.outputs.command }} to equal ${EXPECTED_COMMAND}"
@@ -57,13 +57,13 @@ jobs:
         with:
           token: test_token
           run_group_id: 42
-          description: foo
+          description: foo bar
           custom_url: https://something.com
           release: '1.0'
           dry_run: true
       - name: Custom URL test
         env:
-          EXPECTED_COMMAND: run --skip-update --token test_token --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --custom-url https://something.com --description 'foo' --release '1.0'
+          EXPECTED_COMMAND: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --custom-url https://something.com --description "foo bar" --release "1.0"
         run: |
           if [ "${{ steps.test_custom_url.outputs.command }}" != "${EXPECTED_COMMAND}" ] ; then
             echo "::error ::expected ${{ steps.test_custom_url.outputs.command }} to equal ${EXPECTED_COMMAND}"
@@ -75,14 +75,14 @@ jobs:
         with:
           token: test_token
           run_group_id: 42
-          description: foo
+          description: foo bar
           environment_id: 117
           custom_url: https://something.com
           release: '1.0'
           dry_run: true
       - name: Environment ID and Custom URL test
         env:
-          EXPECTED_COMMAND: run --skip-update --token test_token --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --custom-url https://something.com --description 'foo' --release '1.0'
+          EXPECTED_COMMAND: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --custom-url https://something.com --description "foo bar" --release "1.0"
         run: |
           if [ "${{ steps.test_environment_id_custom_url.outputs.command }}" != "${EXPECTED_COMMAND}" ] ; then
             echo "::error ::expected ${{ steps.test_environment_id_custom_url.outputs.command }} to equal ${EXPECTED_COMMAND}"
@@ -189,7 +189,7 @@ jobs:
           token: test_token
           run_group_id: 42
           environment_id: 117
-          description: foo
+          description: foo bar
           conflict: abort
           crowd: automation
           release: '1.0'
@@ -197,7 +197,7 @@ jobs:
           dry_run: true
       - name: Rerun test
         env:
-          EXPECTED_COMMAND: rerun 343 --skip-update --token test_token --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --conflict abort --release '1.0' --background
+          EXPECTED_COMMAND: rerun 343 --skip-update --token "test_token" --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --conflict abort --release "1.0" --background
         run: |
           if [ "${{ steps.test_rerun.outputs.command }}" != "${EXPECTED_COMMAND}" ] ; then
             echo "::error ::expected ${{ steps.test_rerun.outputs.command }} to equal ${EXPECTED_COMMAND}"

--- a/action.yml
+++ b/action.yml
@@ -154,16 +154,16 @@ runs:
 
         # Set description
         if [ -z "${RAINFOREST_RUN_ID}" ] && [ -n "${{ inputs.description }}" ] ; then
-          RUN_COMMAND="${RUN_COMMAND} --description '${{ inputs.description }}'"
+          RUN_COMMAND="${RUN_COMMAND} --description \"${{ inputs.description }}\""
         elif [ -z "${RAINFOREST_RUN_ID}" ] ; then
-          RUN_COMMAND="${RUN_COMMAND} --description '${GITHUB_REPOSITORY} - ${GITHUB_REF_NAME} ${GITHUB_JOB} $(date -u +'%FT%TZ')'"
+          RUN_COMMAND="${RUN_COMMAND} --description \"${GITHUB_REPOSITORY} - ${GITHUB_REF_NAME} ${GITHUB_JOB} $(date -u +'%FT%TZ')\""
         fi
 
         # Set release
         if [ -n "${{ inputs.release }}" ] ; then
-          RUN_COMMAND="${RUN_COMMAND} --release '${{ inputs.release }}'"
+          RUN_COMMAND="${RUN_COMMAND} --release \"${{ inputs.release }}\""
         elif [ -z "${RAINFOREST_RUN_ID}" ] ; then
-          RUN_COMMAND="${RUN_COMMAND} --release '${GITHUB_SHA}'"
+          RUN_COMMAND="${RUN_COMMAND} --release \"${GITHUB_SHA}\""
         fi
 
         # Set background


### PR DESCRIPTION
#3 changed the `--description` flag to be quoted in single quotes rather than escaped double quotes. This was so that the newly added tests would properly pass; previously, the "base case test" was silently erroring: https://github.com/rainforestapp/github-action/runs/4453199367?check_suite_focus=true#step:5:12

I switched the tests to use the [`pr-mpt/actions-assert` action](https://github.com/marketplace/actions/assert-actual-is-expected), which pass as expected even when using escaped double quotes.

Proof the fix fixes things: https://github.com/rainforestapp/github-action/actions/runs/1553046068