### PR TITLE
Remove the `.rainforest_run_id` file after reading its contents

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
     - name: Set Action Version
       shell: bash
       run: |
-        echo "version=1.0.0" >> $GITHUB_ENV
+        echo "version=1.0.1" >> $GITHUB_ENV
     - name: Check for reruns
       uses: pat-s/always-upload-cache@v2
       if: (! inputs.dry_run)

--- a/action.yml
+++ b/action.yml
@@ -103,6 +103,7 @@ runs:
         # Check for rerun
         if [ -s .rainforest_run_id ] ; then
           RAINFOREST_RUN_ID=$(cat .rainforest_run_id)
+          rm .rainforest_run_id
           echo "Rerunning Run ${RAINFOREST_RUN_ID}"
 
           RUN_COMMAND="rerun \"${RAINFOREST_RUN_ID}\" --skip-update --token \"${{ inputs.token }}\" --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id"


### PR DESCRIPTION
That way, if there is an error while attempting to rerun (for example, because there are no failed tests to rerun), the next attempt will start a new run from scratch (similar to what gets done with the CircleCI Orb).