### PR TITLE
Update cache key to handle multiple runs being triggered by workflows in a single repo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,10 +78,10 @@ runs:
       uses: pat-s/always-upload-cache@v2
       if: (! inputs.dry_run)
       with:
-        key: rainforest-run-${{ github.run_number }}-${{ github.run_attempt }}
+        key: rainforest-run-${{ github.run_id }}-${{ github.action }}-${{ github.run_attempt }}
         path: .rainforest_run_id
         restore-keys: |
-          rainforest-run-${{ github.run_number }}-
+          rainforest-run-${{ github.run_id }}-${{ github.action }}-
     - name: Validate Parameters
       shell: bash
       id: validate

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
     - name: Set Action Version
       shell: bash
       run: |
-        echo "version=2.2.0" >> $GITHUB_ENV
+        echo "version=2.2.1" >> $GITHUB_ENV
     - name: Check for reruns
       uses: pat-s/always-upload-cache@v2
       if: (! inputs.dry_run)


### PR DESCRIPTION
Using `${{ github.run_id }}` rather than `${{ github.run_number }}` allows for multiple workflows triggering Rainforest runs in a single repo.
Using `${{ github.action }}` allows for multiple Rainforest runs being triggered by a single workflow.

Fixes #18