### PR TITLE
Update dependencies to versions that do not use deprecated node runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
     - name: Set Action Version
       shell: bash
       run: |
-        echo "version=2.2.1" >> $GITHUB_ENV
+        echo "version=3.0.0" >> $GITHUB_ENV
     - name: Check for reruns
       uses: pat-s/always-upload-cache@v3
       if: (! inputs.dry_run)

--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
       run: |
         echo "version=2.2.1" >> $GITHUB_ENV
     - name: Check for reruns
-      uses: pat-s/always-upload-cache@v2
+      uses: pat-s/always-upload-cache@v3
       if: (! inputs.dry_run)
       with:
         key: rainforest-run-${{ github.run_id }}-${{ github.action }}-${{ github.run_attempt }}
@@ -223,13 +223,13 @@ runs:
       with:
         args: ${{ steps.validate.outputs.command }}
     - name: Archive Rainforest results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: (! inputs.dry_run) && steps.validate.outputs.command && always()
       with:
         name: Test Results
         path: results/rainforest/junit.xml
     - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v2
+      uses: mikepenz/action-junit-report@v3
       if: (! inputs.dry_run) && steps.validate.outputs.command && always()
       with:
         check_name: Rainforest Results


### PR DESCRIPTION
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Also add dependabot to make updating dependencies easier.