### PR TITLE
[RF-25670] Support starting a run on a branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,21 @@ jobs:
         with:
           actual: ${{ steps.test_environment_id_custom_url.outputs.command }}
           expected: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --custom-url "https://something.com" --description "foo bar" --release "1.0"
+      - name: Branch
+        id: test_branch
+        uses: ./
+        with:
+          token: test_token
+          run_group_id: 42
+          description: foo bar
+          branch: feature-branch
+          release: '1.0'
+          dry_run: true
+      - name: Branch
+        uses: ./.github/actions/test
+        with:
+          actual: ${{ steps.test_branch.outputs.command }}
+          expected: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --branch "feature-branch" --description "foo bar" --release "1.0"
       - name: Missing token command
         id: test_missing_token
         uses: ./

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ Set to a value larger than `0` to retry failed tests excuted by our automation a
 #### Default behavior
 If no `automation_max_retries` parameter is passed in, the [default from your account or run group is used](https://help.rainforestqa.com/docs/test-retries).
 
+### `branch`
+Use a specific Rainforest branch for this run.
+#### Default behavior
+If no `branch_name` parameter is passed in, the `main` branch will be used.
+
 ## Rerunning failed tests
 If your Rainforest run fails due to a ["non-bug"](https://rainforest.engineering/2021-01-20-shipping-faster-orb/) (your testing environment might have had a hiccup, or a test might have needed to be tweaked, etc), then rather than make code changes and then run your full testing suite once more, you'll instead want to rerun just the tests that failed. The Rainforest QA GitHub Action uses GitHub [caching](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows) to know when a workflow is [being rerun](https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs). It will then automatically rerun only the tests which failed in the previous run.
 

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,11 @@ inputs:
     required: false
     default: ''
 
+  branch:
+    description: Use a specific Rainforest branch for this run
+    required: false
+    default: ''
+
 outputs:
   command:
     description: The CLI command that was run
@@ -192,6 +197,11 @@ runs:
           else
             error "automation_max_retries not a positive integer (${{ inputs.automation_max_retries }})"
           fi
+        fi
+
+        # Set branch
+        if [ -n "${{ inputs.branch }}" ] ; then
+          RUN_COMMAND="${RUN_COMMAND} --branch \"${{ inputs.branch }}\""
         fi
 
         # Set description


### PR DESCRIPTION
Add support for a `branch` param which allows you specify which `Rainforest` branch should be used for the run.