### PR TITLE
[RF-25710] Add optional `cache_key` parameter to support multiple calls via `workflow_call`

### DIFF
--- a/.github/workflows/rainforest.yml
+++ b/.github/workflows/rainforest.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Run Rainforest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Rainforest
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           actual: ${{ steps.test_environment_id_custom_url.outputs.command }}
           expected: run --skip-update --token "test_token" --run-group 42 --junit-file results/rainforest/junit.xml --save-run-id .rainforest_run_id --custom-url "https://something.com" --description "foo bar" --release "1.0"
-      - name: Branch
+      - name: Branch command
         id: test_branch
         uses: ./
         with:
@@ -87,7 +87,7 @@ jobs:
           branch: feature-branch
           release: '1.0'
           dry_run: true
-      - name: Branch
+      - name: Branch test
         uses: ./.github/actions/test
         with:
           actual: ${{ steps.test_branch.outputs.command }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install faketime
         run: |
           sudo apt-get update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,7 @@ jobs:
           environment_id: 117
           description: foo bar
           conflict: cancel
-          crowd: automation
+          execution_method: automation
           release: '1.0'
           background: true
           dry_run: true

--- a/README.md
+++ b/README.md
@@ -96,11 +96,6 @@ A string used to link a run to a release (for example, a `git` SHA or tag, a ver
 #### Default behavior
 If no `release` parameter is passed in, the SHA1 hash of the latest commit of the current workflow (obtained via the `GITHUB_SHA` environment variable) will be used.
 
-### `dry_run`
-Set to `true` to run parameter validations without actually starting a run in Rainforest.
-#### Default behavior
-If no `dry_run` parameter is passed in, the run will be started in Rainforest.
-
 ### `automation_max_retries`
 Set to a value larger than `0` to retry failed tests excuted by our automation agent in the same run up to that number of times.
 #### Default behavior
@@ -110,6 +105,16 @@ If no `automation_max_retries` parameter is passed in, the [default from your ac
 Use a specific Rainforest branch for this run.
 #### Default behavior
 If no `branch` parameter is passed in, the `main` branch will be used.
+
+### `background`
+Set to `true` to immediately complete the GitHub workflow job without waiting for the Rainforest run to complete
+### Default behavior
+By default we wait for the run to complete in order to pass or fail the workflow job based on the run's result.
+
+### `dry_run`
+Set to `true` to run parameter validations without actually starting a run in Rainforest.
+#### Default behavior
+If no `dry_run` parameter is passed in, the run will be started in Rainforest.
 
 ## Rerunning failed tests
 If your Rainforest run fails due to a ["non-bug"](https://rainforest.engineering/2021-01-20-shipping-faster-orb/) (your testing environment might have had a hiccup, or a test might have needed to be tweaked, etc), then rather than make code changes and then run your full testing suite once more, you'll instead want to rerun just the tests that failed. The Rainforest QA GitHub Action uses GitHub [caching](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows) to know when a workflow is [being rerun](https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs). It will then automatically rerun only the tests which failed in the previous run.

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
     - name: Set Action Version
       shell: bash
       run: |
-        echo "version=3.0.0" >> $GITHUB_ENV
+        echo "version=3.2.0" >> $GITHUB_ENV
     - name: Check for reruns
       uses: pat-s/always-upload-cache@v3
       if: (! inputs.dry_run)

--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,11 @@ inputs:
     required: false
     default: ''
 
+  cache_key:
+    description: The cache key to use for saving/restoring a Rainforest run ID (used to rerun failed tests)
+    required: false
+    default: '${{ github.action }}'
+
 outputs:
   command:
     description: The CLI command that was run
@@ -92,10 +97,10 @@ runs:
       uses: pat-s/always-upload-cache@v3
       if: (! inputs.dry_run)
       with:
-        key: rainforest-run-${{ github.run_id }}-${{ github.action }}-${{ github.run_attempt }}
+        key: rainforest-run-${{ github.run_id }}-${{ inputs.cache_key }}-${{ github.run_attempt }}
         path: .rainforest_run_id
         restore-keys: |
-          rainforest-run-${{ github.run_id }}-${{ github.action }}-
+          rainforest-run-${{ github.run_id }}-${{ inputs.cache_key }}-
     - name: Validate Parameters
       shell: bash
       id: validate

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ inputs:
   cache_key:
     description: The cache key to use for saving/restoring a Rainforest run ID (used to rerun failed tests)
     required: false
-    default: '${{ github.action }}'
+    default: '${{ github.job }}-${{ github.action }}'
 
 outputs:
   command:

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,7 @@ inputs:
     description: "DEPRECATED: Use `execution_method` instead"
     required: false
     default: ''
+    deprecationMessage: "Use `execution_method` instead. For more information, see https://github.com/rainforestapp/github-action/releases/tag/v2.1.0."
 
   release:
     description: Manually entered release information about the release the run is associated with
@@ -185,7 +186,6 @@ runs:
           fi
 
           if [ -n "${{ inputs.crowd }}" ] ; then
-            echo "::warning The 'crowd' parameter is deprecated, use 'execution_method' instead."
             if [ -n "${{ inputs.execution_method }}" ] ; then
               error "Error: execution_method and crowd are mutually exclusive"
             fi

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: Rainforest QA GitHub Action
 description: Easily trigger a Rainforest Run from your GitHub workflows
 inputs:
+  #
+  # Rainforest API parameters
+  #
   description:
     description: An arbitrary string to associate with the run
     required: false
@@ -40,20 +43,6 @@ inputs:
     required: false
     default: ''
 
-  token:
-    description: Your Rainforest QA API token
-    required: true
-
-  dry_run:
-    description: Set to true to run parameter validations without starting a new Rainforest run
-    required: false
-    default: ''
-
-  background:
-    description: Do not wait for a run to complete before exiting
-    required: false
-    default: ''
-
   automation_max_retries:
     description: If set to a value > 0 and a test fails, it will be retried within the same run, up to that number of times
     required: false
@@ -61,6 +50,26 @@ inputs:
 
   branch:
     description: Use a specific Rainforest branch for this run
+    required: false
+    default: ''
+
+  token:
+    description: Your Rainforest QA API token
+    required: true
+
+  #
+  # Rainforest CLI flags
+  #
+  background:
+    description: Do not wait for a run to complete before exiting
+    required: false
+    default: ''
+
+  #
+  # GitHub Action-specific inputs
+  #
+  dry_run:
+    description: Set to true to run parameter validations without starting a new Rainforest run
     required: false
     default: ''
 

--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,7 @@ runs:
         # Define error helper
         error () {
           echo "::error ::${1}"
-          echo "::set-output name=error::${1}"
+          echo "error=${1}" >> $GITHUB_OUTPUT
           exit 1
         }
 
@@ -237,7 +237,7 @@ runs:
           RUN_COMMAND="${RUN_COMMAND} --background"
         fi
 
-        echo "::set-output name=command::${RUN_COMMAND}"
+        echo "command=${RUN_COMMAND}" >> $GITHUB_OUTPUT
 
     - name: Run Rainforest
       uses: docker://gcr.io/rf-public-images/rainforest-cli:latest


### PR DESCRIPTION
The main change in this PR is adding a new optional `cache_key` parameter to fix this edge case:

When calling the action from a reusable (`on: workflow_call`) workflow, if the calling workflow calls the reusable workflow more than once, subsequent calls attempt to rerun the run from the first call rather than triggering their own calls.

Unfortunately, GitHub doesn't provide us with a reference to unique job IDs coming from the calling workflow, all we get is the shared job ID from the reusable workflow. Allowing users to set the cache key themselves will let them get around this issue.

The other changes are mainly cleanup related to documentation (reordering parameters, using `inputs.deprecationMessage`) and a couple of deprecation fixes.