### PR TITLE
Fix example documenting how to use cache_key input parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ jobs:
         with:
           token: ${{ secrets.RAINFOREST_API_TOKEN }}
           run_group_id: 1234
+          cache_key: ${{ inputs.cache_key }}
 ```
 
 ```yml


### PR DESCRIPTION
I've updated the `v3.2.0` release notes: https://github.com/rainforestapp/github-action/releases/tag/v3.2.0