### PR TITLE
[RF-31415] Fix setting of version when starting a run

### DIFF
--- a/.github/workflows/rainforest.yml
+++ b/.github/workflows/rainforest.yml
@@ -15,3 +15,15 @@ jobs:
         with:
           token: ${{ secrets.RF_MAIN_API_TOKEN }}
           run_group_id: 9861
+      - name: Get run source
+        id: get_run_source
+        env:
+          token: ${{ secrets.RF_MAIN_API_TOKEN }}
+        run: |
+          source=$(curl -s -X GET -H "Client-Token: $token" "https://app.rainforestqa.com/api/1/runs/$(cat .rainforest_run_id)?slim=true" | jq -r ".source")
+          echo "source=$source" >> "$GITHUB_OUTPUT"
+      - name: Test run source
+        uses: ./.github/actions/test
+        with:
+          actual: ${{ steps.get_run_source.outputs.source }}
+          expected: rainforest-gh-action

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
     - name: Set Action Version
       shell: bash
       run: |
-        echo "RF_ACTION_VERSION=3.2.4" >> $GITHUB_ENV
+        echo "RF_ACTION_VERSION=3.2.5" >> $GITHUB_ENV
     - name: Check for reruns
       uses: pat-s/always-upload-cache@v3
       if: (! inputs.dry_run)

--- a/action.yml
+++ b/action.yml
@@ -127,7 +127,7 @@ runs:
       uses: docker://gcr.io/rf-public-images/rainforest-cli:latest
       if: (! inputs.dry_run)
       env:
-        GH_ACTION_VERSION: ${{ env.version }}
+        GH_ACTION_VERSION: ${{ env.RF_ACTION_VERSION }}
       with:
         args: ${{ steps.validate.outputs.command }}
     - name: Archive Rainforest results


### PR DESCRIPTION
This is used by the CLI to mark the run as being initiated by the GH Action: https://github.com/rainforestapp/rainforest-cli/blob/v3.5.0/rainforest-cli.go#L106-L110, and broken in https://github.com/rainforestapp/github-action/pull/32/commits/422af7e52ce7a27cd9476da5bd3c3346ffa5482a.

I temporarily enabled the `rainforest` workflow on this branch to test the fix:

Prior to the fix: https://github.com/rainforestapp/github-action/actions/runs/6884662525/job/18727576457#step:5:25
> ❌ compared rainforest-cli to rainforest-gh-action

After the fix: https://github.com/rainforestapp/github-action/actions/runs/6884752372/job/18727819110#step:5:25
> ✅ compared rainforest-gh-action to rainforest-gh-action

