### PR TITLE
Use `cache@v4` and `save-always` option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -95,9 +95,10 @@ runs:
       run: |
         echo "RF_ACTION_VERSION=3.2.5" >> $GITHUB_ENV
     - name: Check for reruns
-      uses: pat-s/always-upload-cache@v3
+      uses: actions/cache@v4
       if: (! inputs.dry_run)
       with:
+        save-always: true
         key: rainforest-run-${{ github.run_id }}-${{ inputs.cache_key }}-${{ github.run_attempt }}
         path: .rainforest_run_id
         restore-keys: |


### PR DESCRIPTION
Cheers lovely people of rainforest!

### TLDR
Use github's cache action and it's `save-always` option instead of a fork that still uses node 16.

### Long story
So I noticed a Node 16 warning when running my RF suite
<img width="907" alt="Screenshot 2024-06-14 at 17 10 33" src="https://github.com/rainforestapp/github-action/assets/2325802/e885600a-5ccc-4520-9fed-b1912dce3a31">

I checked out [always-upload-cache](https://github.com/pat-s/always-upload-cache) action but it seems neglected. I started looking into [Github's cache action issue](https://github.com/actions/cache/issues/92) linked in its README and noticed that the [v4 Changelog](https://github.com/actions/cache?tab=readme-ov-file#v4) mentions a `save-always` option.

While it's not documented a quick peek [the code](https://github.com/actions/cache/blob/0c45773b623bea8c8e75f6c82b208c3cf94ea4f9/action.yml#L29-L32) suggests it does exactly what always-upload-cache does.

I haven't tested that yet, I'm planning to test in next week on my suite.